### PR TITLE
REC-3666 preview distorted after camera rotation

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -187,6 +187,7 @@ public class CameraActivity extends Fragment {
             );
             mainLayout.addView(mPreview);
             mainLayout.setEnabled(false);
+            mPreview.setCameraActivity(this);
 
             if (tapToFocus || enableZoom) {
                 this.setupTouchAndBackButton();

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -180,14 +180,13 @@ public class CameraActivity extends Fragment {
             frameContainerLayout.setLayoutParams(layoutParams);
 
             //video view
-            mPreview = new Preview(getActivity(), enableOpacity);
+            mPreview = new Preview(getActivity(), enableOpacity, this);
             mainLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("video_view", "id", appResourcesPackage));
             mainLayout.setLayoutParams(
                 new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT)
             );
             mainLayout.addView(mPreview);
             mainLayout.setEnabled(false);
-            mPreview.setCameraActivity(this);
 
             if (tapToFocus || enableZoom) {
                 this.setupTouchAndBackButton();

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -384,7 +384,7 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
     }
 
     private void restartCamera() {
-        Log.e(TAG, "no fitting preview size found - restarting camera");
+        Log.w(TAG, "no fitting preview size found - restarting camera");
         fragment.onPause();
         fragment.onResume();
     }

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.widget.RelativeLayout;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureView.SurfaceTextureListener {
 
@@ -389,12 +390,13 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
     }
 
     private boolean trySetPreviewSize(Camera.Parameters parameters, Camera.Size size) {
-        parameters.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
+        parameters.setPreviewSize(size.width, size.height);
         requestLayout();
         try {
             mCamera.setParameters(parameters);
         } catch (RuntimeException e) {
-            return false;
+            Log.w(TAG, "trySetPreviewSize failed with: " + e);
+            return e.getMessage() == null || !e.getMessage().contains("setParameters failed");
         }
         return true;
     }

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -390,13 +390,20 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
     }
 
     private boolean trySetPreviewSize(Camera.Parameters parameters, Camera.Size size) {
+        Camera.Size rollbackValue = parameters.getPreviewSize();
         parameters.setPreviewSize(size.width, size.height);
         requestLayout();
         try {
             mCamera.setParameters(parameters);
         } catch (RuntimeException e) {
             Log.w(TAG, "trySetPreviewSize failed with: " + e);
-            return e.getMessage() == null || !e.getMessage().contains("setParameters failed");
+            if(e.getMessage() != null && e.getMessage().contains("setParameters failed"))
+            {
+                parameters.setPreviewSize(rollbackValue.width, rollbackValue.height);
+                requestLayout();
+                return false;
+            }
+            return true;
         }
         return true;
     }

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -303,14 +303,6 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
         return (Math.abs(ratio - targetRatio) < aspectTolerance);
     }
 
-    private double computeTargetRatio(int w, int h) {
-        return (displayOrientation == 0 || displayOrientation == 180) ? (double) w / h : (double) h / w;
-    }
-
-    private double computeTargetHeight(int w, int h) {
-        return (displayOrientation == 0 || displayOrientation == 180) ? h : w;
-    }
-
     private boolean trySetPreviewSize(Camera.Size size) {
         Camera.Parameters parameters = mCamera.getParameters();
         Camera.Size rollbackValue = parameters.getPreviewSize();
@@ -407,6 +399,14 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
             }
             return Double.compare(ratioDiff1, ratioDiff2);
         });
+    }
+
+    private double computeTargetRatio(int w, int h) {
+        return (displayOrientation == 0 || displayOrientation == 180) ? (double) w / h : (double) h / w;
+    }
+
+    private double computeTargetHeight(int w, int h) {
+        return (displayOrientation == 0 || displayOrientation == 180) ? h : w;
     }
 
     public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {}

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -33,13 +33,9 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
     private boolean enableOpacity = false;
     private float opacity = 1F;
 
-    private CameraActivity fragment;
+    private final CameraActivity fragment;
 
-    Preview(Context context) {
-        this(context, false);
-    }
-
-    Preview(Context context, boolean enableOpacity) {
+    Preview(Context context, boolean enableOpacity, CameraActivity cameraActivity) {
         super(context);
         this.enableOpacity = enableOpacity;
         if (!enableOpacity) {
@@ -61,6 +57,7 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
             addView(mTextureView);
             requestLayout();
         }
+        fragment = cameraActivity;
     }
 
     public void setCamera(Camera camera, int cameraId) {
@@ -83,10 +80,6 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
             }
             mCamera.setParameters(params);
         }
-    }
-
-    public void setCameraActivity(CameraActivity cameraActivity) {
-        fragment = cameraActivity;
     }
 
     public int getDisplayOrientation() {

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -33,6 +33,8 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
     private boolean enableOpacity = false;
     private float opacity = 1F;
 
+    private CameraActivity fragment;
+
     Preview(Context context) {
         this(context, false);
     }
@@ -81,6 +83,10 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
             }
             mCamera.setParameters(params);
         }
+    }
+
+    public void setCameraActivity(CameraActivity cameraActivity) {
+        fragment = cameraActivity;
     }
 
     public int getDisplayOrientation() {

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -313,16 +313,18 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
             parameters.setPreviewSize(size.width, size.height);
             requestLayout();
             mCamera.setParameters(parameters);
-        } catch (RuntimeException e) {
-            Log.w(TAG, "trySetPreviewSize failed with: " + e);
-            if(e.getMessage() != null && e.getMessage().contains("setParameters failed"))
-            {
-                mPreviewSize = rollbackValue;
-                parameters.setPreviewSize(rollbackValue.width, rollbackValue.height);
-                requestLayout();
+        } catch (RuntimeException exception) {
+            Log.w(TAG, "trySetPreviewSize failed with: " + exception);
+            mPreviewSize = rollbackValue;
+            parameters.setPreviewSize(rollbackValue.width, rollbackValue.height);
+            requestLayout();
+
+            if(exception.getMessage() != null && exception.getMessage().contains("setParameters failed")) {
                 return false;
             }
-            return true;
+            else {
+                Log.e(TAG, "Exception caused by surfaceChanged()", exception);
+            }
         }
         return true;
     }


### PR DESCRIPTION
Problem war eine exception bei `mCamera.setParameters(parameters);` nach ändern der `PreviewSize` bei manchen devices. 

Mit zwei Änderungen sollte jetzt auf allen Geräten der Preview richtig angezeigt werden:
- zuerst wird versucht eine andere PreviewSize aus der Liste der unterstützten Formate zu verwenden.
- wenn nichts gefunden wird, wird die Kamera neu gestartet. Wobei das kaum auffällt weil nicht die ganze Activity neu gestartet werden muss. 

Nach Kamera Neustart scheint es keine Probleme mit dem `PreviewSize` Parameter zu geben. Warum das genau bei der Rotation hin und wieder nicht klappt ist leider nicht so einfach herauszufinden.