### PR TITLE
iOS autofocus improvements

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -233,132 +233,132 @@ public class CameraActivity extends Fragment {
         });
 
         getActivity()
-                .runOnUiThread(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                frameContainerLayout.setClickable(true);
-                                frameContainerLayout.setOnTouchListener(
-                                        new View.OnTouchListener() {
-                                            private int mLastTouchX;
-                                            private int mLastTouchY;
-                                            private int mPosX = 0;
-                                            private int mPosY = 0;
+            .runOnUiThread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        frameContainerLayout.setClickable(true);
+                        frameContainerLayout.setOnTouchListener(
+                            new View.OnTouchListener() {
+                                private int mLastTouchX;
+                                private int mLastTouchY;
+                                private int mPosX = 0;
+                                private int mPosY = 0;
 
-                                            @Override
-                                            public boolean onTouch(View v, MotionEvent event) {
-                                                FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) frameContainerLayout.getLayoutParams();
+                                @Override
+                                public boolean onTouch(View v, MotionEvent event) {
+                                    FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) frameContainerLayout.getLayoutParams();
 
-                                                boolean isSingleTapTouch = gestureDetector.onTouchEvent(event);
-                                                int action = event.getAction();
-                                                int eventCount = event.getPointerCount();
-                                                Log.d(TAG, "onTouch event, action, count: " + event + ", " + action + ", " + eventCount);
-                                                if (action == MotionEvent.ACTION_DOWN) {
-                                                    mDist = 0;
-                                                }
-                                                if (eventCount > 1) {
-                                                    // handle multi-touch events
-                                                    Camera.Parameters params = mCamera.getParameters();
-                                                    if (action == MotionEvent.ACTION_MOVE && params.isZoomSupported()) {
-                                                        handleZoom(event, params);
-                                                    }
-                                                } else if((action == MotionEvent.ACTION_MOVE || !isSingleTapTouch) && dragEnabled) {
-                                                    int x;
-                                                    int y;
-
-                                                    switch (event.getAction()) {
-                                                        case MotionEvent.ACTION_DOWN:
-                                                            if (mLastTouchX == 0 || mLastTouchY == 0) {
-                                                                mLastTouchX = (int) event.getRawX() - layoutParams.leftMargin;
-                                                                mLastTouchY = (int) event.getRawY() - layoutParams.topMargin;
-                                                            } else {
-                                                                mLastTouchX = (int) event.getRawX();
-                                                                mLastTouchY = (int) event.getRawY();
-                                                            }
-                                                            break;
-                                                        case MotionEvent.ACTION_MOVE:
-                                                            x = (int) event.getRawX();
-                                                            y = (int) event.getRawY();
-
-                                                            final float dx = x - mLastTouchX;
-                                                            final float dy = y - mLastTouchY;
-
-                                                            mPosX += dx;
-                                                            mPosY += dy;
-
-                                                            layoutParams.leftMargin = mPosX;
-                                                            layoutParams.topMargin = mPosY;
-
-                                                            frameContainerLayout.setLayoutParams(layoutParams);
-
-                                                            // Remember this touch position for the next move event
-                                                            mLastTouchX = x;
-                                                            mLastTouchY = y;
-
-                                                            break;
-                                                        default:
-                                                            break;
-                                                    }
-                                                }
-                                                return true;
-                                            }
+                                    boolean isSingleTapTouch = gestureDetector.onTouchEvent(event);
+                                    int action = event.getAction();
+                                    int eventCount = event.getPointerCount();
+                                    Log.d(TAG, "onTouch event, action, count: " + event + ", " + action + ", " + eventCount);
+                                    if (action == MotionEvent.ACTION_DOWN) {
+                                        mDist = 0;
+                                    }
+                                    if (eventCount > 1) {
+                                        // handle multi-touch events
+                                        Camera.Parameters params = mCamera.getParameters();
+                                        if (action == MotionEvent.ACTION_MOVE && params.isZoomSupported()) {
+                                            handleZoom(event, params);
                                         }
-                                );
-                                frameContainerLayout.setFocusableInTouchMode(true);
-                                frameContainerLayout.requestFocus();
-                                frameContainerLayout.setOnKeyListener(
-                                        new View.OnKeyListener() {
-                                            @Override
-                                            public boolean onKey(View v, int keyCode, android.view.KeyEvent event) {
-                                                if (keyCode == android.view.KeyEvent.KEYCODE_BACK) {
-                                                    eventListener.onBackButton();
-                                                    return true;
+                                    } else if((action == MotionEvent.ACTION_MOVE || !isSingleTapTouch) && dragEnabled) {
+                                        int x;
+                                        int y;
+
+                                        switch (event.getAction()) {
+                                            case MotionEvent.ACTION_DOWN:
+                                                if (mLastTouchX == 0 || mLastTouchY == 0) {
+                                                    mLastTouchX = (int) event.getRawX() - layoutParams.leftMargin;
+                                                    mLastTouchY = (int) event.getRawY() - layoutParams.topMargin;
+                                                } else {
+                                                    mLastTouchX = (int) event.getRawX();
+                                                    mLastTouchY = (int) event.getRawY();
                                                 }
-                                                return false;
-                                            }
+                                                break;
+                                            case MotionEvent.ACTION_MOVE:
+                                                x = (int) event.getRawX();
+                                                y = (int) event.getRawY();
+
+                                                final float dx = x - mLastTouchX;
+                                                final float dy = y - mLastTouchY;
+
+                                                mPosX += dx;
+                                                mPosY += dy;
+
+                                                layoutParams.leftMargin = mPosX;
+                                                layoutParams.topMargin = mPosY;
+
+                                                frameContainerLayout.setLayoutParams(layoutParams);
+                                                        
+                                                // Remember this touch position for the next move event
+                                                mLastTouchX = x;
+                                                mLastTouchY = y;
+
+                                                break;
+                                            default:
+                                                break;
                                         }
-                                );
+                                    }
+                                    return true;
+                                }
                             }
-
-                            private float mDist = 0F;
-
-                            private void handleZoom(MotionEvent event, Camera.Parameters params) {
-                                if (mCamera == null) {
-                                    return;
+                        );
+                        frameContainerLayout.setFocusableInTouchMode(true);
+                        frameContainerLayout.requestFocus();
+                        frameContainerLayout.setOnKeyListener(
+                            new View.OnKeyListener() {
+                                @Override
+                                public boolean onKey(View v, int keyCode, android.view.KeyEvent event) {
+                                    if (keyCode == android.view.KeyEvent.KEYCODE_BACK) {
+                                        eventListener.onBackButton();
+                                        return true;
+                                    }
+                                    return false;
                                 }
-
-                                mCamera.cancelAutoFocus();
-
-                                int maxZoom = params.getMaxZoom();
-                                int zoom = params.getZoom();
-                                float newDist = getFingerSpacing(event);
-                                float distDifference = newDist - mDist;
-
-                                // avoid zoom jumps
-                                if(mDist == 0) {
-                                    mDist = newDist;
-                                    return;
-                                }
-
-                                int zoomDifference = 0;
-                                int zoomFactor = 10;
-                                int maximumZoomStep = 10;
-
-                                if (newDist > mDist) {
-                                    //zoom in;
-                                    zoomDifference = Math.min(Math.round(distDifference / zoomFactor), maximumZoomStep);
-                                    zoom = Math.min(maxZoom, zoom + zoomDifference);
-                                } else if (newDist < mDist) {
-                                    //zoom out
-                                    zoomDifference = Math.max(Math.round(distDifference / zoomFactor), -maximumZoomStep);
-                                    zoom = Math.max(0, zoom + zoomDifference);
-                                }
-                                mDist = newDist;
-                                params.setZoom(zoom);
-                                mCamera.setParameters(params);
                             }
+                        );
+                    }
+
+                    private float mDist = 0F;
+
+                    private void handleZoom(MotionEvent event, Camera.Parameters params) {
+                        if (mCamera == null) {
+                            return;
                         }
-                );
+
+                        mCamera.cancelAutoFocus();
+
+                        int maxZoom = params.getMaxZoom();
+                        int zoom = params.getZoom();
+                        float newDist = getFingerSpacing(event);
+                        float distDifference = newDist - mDist;
+
+                        // avoid zoom jumps
+                        if(mDist == 0) {
+                            mDist = newDist;
+                            return;
+                        }
+
+                        int zoomDifference = 0;
+                        int zoomFactor = 10;
+                        int maximumZoomStep = 10;
+
+                        if (newDist > mDist) {
+                            //zoom in;
+                            zoomDifference = Math.min(Math.round(distDifference / zoomFactor), maximumZoomStep);
+                            zoom = Math.min(maxZoom, zoom + zoomDifference);
+                        } else if (newDist < mDist) {
+                            //zoom out
+                            zoomDifference = Math.max(Math.round(distDifference / zoomFactor), -maximumZoomStep);
+                            zoom = Math.max(0, zoom + zoomDifference);
+                        }
+                        mDist = newDist;
+                        params.setZoom(zoom);
+                        mCamera.setParameters(params);
+                    }
+                }
+            );
     }
 
     private void setDefaultCameraId() {
@@ -401,33 +401,33 @@ public class CameraActivity extends Fragment {
         Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
 
         final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(
-                getResources().getIdentifier("frame_container", "id", appResourcesPackage)
+            getResources().getIdentifier("frame_container", "id", appResourcesPackage)
         );
 
         ViewTreeObserver viewTreeObserver = frameContainerLayout.getViewTreeObserver();
 
         if (viewTreeObserver.isAlive()) {
             viewTreeObserver.addOnGlobalLayoutListener(
-                    new ViewTreeObserver.OnGlobalLayoutListener() {
-                        @Override
-                        public void onGlobalLayout() {
-                            frameContainerLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-                            frameContainerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
-                            Activity activity = getActivity();
-                            if (isAdded() && activity != null) {
-                                final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(
-                                        getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
-                                );
+                new ViewTreeObserver.OnGlobalLayoutListener() {
+                    @Override
+                    public void onGlobalLayout() {
+                        frameContainerLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                        frameContainerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+                        Activity activity = getActivity();
+                        if (isAdded() && activity != null) {
+                            final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(
+                                getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
+                            );
 
-                                FrameLayout.LayoutParams camViewLayout = new FrameLayout.LayoutParams(
-                                        frameContainerLayout.getWidth(),
-                                        frameContainerLayout.getHeight()
-                                );
-                                camViewLayout.gravity = Gravity.CENTER_HORIZONTAL | Gravity.CENTER_VERTICAL;
-                                frameCamContainerLayout.setLayoutParams(camViewLayout);
-                            }
+                            FrameLayout.LayoutParams camViewLayout = new FrameLayout.LayoutParams(
+                                    frameContainerLayout.getWidth(),
+                                    frameContainerLayout.getHeight()
+                            );
+                            camViewLayout.gravity = Gravity.CENTER_HORIZONTAL | Gravity.CENTER_VERTICAL;
+                            frameCamContainerLayout.setLayoutParams(camViewLayout);
                         }
                     }
+                }
             );
         }
     }
@@ -451,16 +451,16 @@ public class CameraActivity extends Fragment {
         super.onConfigurationChanged(newConfig);
 
         final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(
-                getResources().getIdentifier("frame_container", "id", appResourcesPackage)
+            getResources().getIdentifier("frame_container", "id", appResourcesPackage)
         );
 
         final int previousOrientation = frameContainerLayout.getHeight() > frameContainerLayout.getWidth()
-                ? Configuration.ORIENTATION_PORTRAIT
-                : Configuration.ORIENTATION_LANDSCAPE;
+            ? Configuration.ORIENTATION_PORTRAIT
+            : Configuration.ORIENTATION_LANDSCAPE;
         // Checks if the orientation of the screen has changed
         if (newConfig.orientation != previousOrientation) {
             final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(
-                    getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
+                getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
             );
 
             frameContainerLayout.getLayoutParams().width = frameCamContainerLayout.getHeight();
@@ -640,10 +640,10 @@ public class CameraActivity extends Fragment {
     };
 
     private Camera.Size getOptimalPictureSize(
-            final int width,
-            final int height,
-            final Camera.Size previewSize,
-            final List<Camera.Size> supportedSizes
+        final int width,
+        final int height,
+        final Camera.Size previewSize,
+        final List<Camera.Size> supportedSizes
     ) {
         /*
       get the supportedPictureSize that:
@@ -704,8 +704,8 @@ public class CameraActivity extends Fragment {
                 } else {
                     // check if this pictureSize closer to requested width and height
                     if (
-                            Math.abs(width * height - supportedSize.width * supportedSize.height) <
-                                    Math.abs(width * height - size.width * size.height)
+                        Math.abs(width * height - supportedSize.width * supportedSize.height) <
+                        Math.abs(width * height - size.width * size.height)
                     ) {
                         size.width = supportedSize.width;
                         size.height = supportedSize.height;
@@ -762,36 +762,36 @@ public class CameraActivity extends Fragment {
 
     public void takeSnapshot(final int quality) {
         mCamera.setPreviewCallback(
-                new Camera.PreviewCallback() {
-                    @Override
-                    public void onPreviewFrame(byte[] bytes, Camera camera) {
-                        try {
-                            Camera.Parameters parameters = camera.getParameters();
-                            Camera.Size size = parameters.getPreviewSize();
-                            int orientation = mPreview.getDisplayOrientation();
-                            if (mPreview.getCameraFacing() == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-                                bytes = rotateNV21(bytes, size.width, size.height, (360 - orientation) % 360);
-                            } else {
-                                bytes = rotateNV21(bytes, size.width, size.height, orientation);
-                            }
-                            // switch width/height when rotating 90/270 deg
-                            Rect rect = orientation == 90 || orientation == 270
-                                    ? new Rect(0, 0, size.height, size.width)
-                                    : new Rect(0, 0, size.width, size.height);
-                            YuvImage yuvImage = new YuvImage(bytes, parameters.getPreviewFormat(), rect.width(), rect.height(), null);
-                            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                            yuvImage.compressToJpeg(rect, quality, byteArrayOutputStream);
-                            byte[] data = byteArrayOutputStream.toByteArray();
-                            byteArrayOutputStream.close();
-                            eventListener.onSnapshotTaken(Base64.encodeToString(data, Base64.NO_WRAP));
-                        } catch (IOException e) {
-                            Log.d(TAG, "CameraPreview IOException");
-                            eventListener.onSnapshotTakenError("IO Error");
-                        } finally {
-                            mCamera.setPreviewCallback(null);
+            new Camera.PreviewCallback() {
+                @Override
+                public void onPreviewFrame(byte[] bytes, Camera camera) {
+                    try {
+                        Camera.Parameters parameters = camera.getParameters();
+                        Camera.Size size = parameters.getPreviewSize();
+                        int orientation = mPreview.getDisplayOrientation();
+                        if (mPreview.getCameraFacing() == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+                            bytes = rotateNV21(bytes, size.width, size.height, (360 - orientation) % 360);
+                        } else {
+                            bytes = rotateNV21(bytes, size.width, size.height, orientation);
                         }
-                    }
+                        // switch width/height when rotating 90/270 deg
+                        Rect rect = orientation == 90 || orientation == 270
+                                ? new Rect(0, 0, size.height, size.width)
+                                : new Rect(0, 0, size.width, size.height);
+                        YuvImage yuvImage = new YuvImage(bytes, parameters.getPreviewFormat(), rect.width(), rect.height(), null);
+                        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                        yuvImage.compressToJpeg(rect, quality, byteArrayOutputStream);
+                        byte[] data = byteArrayOutputStream.toByteArray();
+                        byteArrayOutputStream.close();
+                        eventListener.onSnapshotTaken(Base64.encodeToString(data, Base64.NO_WRAP));
+                    } catch (IOException e) {
+                        Log.d(TAG, "CameraPreview IOException");
+                        eventListener.onSnapshotTakenError("IO Error");
+                    } finally {
+                        mCamera.setPreviewCallback(null);
+                        }
                 }
+            }
         );
     }
 
@@ -857,20 +857,20 @@ public class CameraActivity extends Fragment {
                     mCamera.takePicture(shutterCallback, null, jpegPictureCallback);
                 }
             }
-                    .start();
+                .start();
         } else {
             canTakePicture = true;
         }
     }
 
     public void startRecord(
-            final String filePath,
-            final String camera,
-            final int width,
-            final int height,
-            final int quality,
-            final boolean withFlash,
-            final int maxDuration
+        final String filePath,
+        final String camera,
+        final int width,
+        final int height,
+        final int quality,
+        final boolean withFlash,
+        final int maxDuration
     ) {
         Log.d(TAG, "CameraPreview startRecord camera: " + camera + " width: " + width + ", height: " + height + ", quality: " + quality);
         Activity activity = getActivity();
@@ -1022,10 +1022,10 @@ public class CameraActivity extends Fragment {
             y = height - 100;
         }
         return new Rect(
-                Math.round((x - 100) * 2000 / width - 1000),
-                Math.round((y - 100) * 2000 / height - 1000),
-                Math.round((x + 100) * 2000 / width - 1000),
-                Math.round((y + 100) * 2000 / height - 1000)
+            Math.round((x - 100) * 2000 / width - 1000),
+            Math.round((y - 100) * 2000 / height - 1000),
+            Math.round((x + 100) * 2000 / width - 1000),
+            Math.round((y + 100) * 2000 / height - 1000)
         );
     }
 

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -178,14 +178,14 @@ public class CameraActivity extends Fragment {
             FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(width, height);
             layoutParams.setMargins(x, y, 0, 0);
             frameContainerLayout =
-                    (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
+                (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
             frameContainerLayout.setLayoutParams(layoutParams);
 
             //video view
             mPreview = new Preview(getActivity(), enableOpacity, this);
             mainLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("video_view", "id", appResourcesPackage));
             mainLayout.setLayoutParams(
-                    new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT)
+                new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT)
             );
             mainLayout.addView(mPreview);
             mainLayout.setEnabled(false);
@@ -290,7 +290,7 @@ public class CameraActivity extends Fragment {
                                                 layoutParams.topMargin = mPosY;
 
                                                 frameContainerLayout.setLayoutParams(layoutParams);
-                                                        
+    
                                                 // Remember this touch position for the next move event
                                                 mLastTouchX = x;
                                                 mLastTouchY = y;
@@ -420,8 +420,8 @@ public class CameraActivity extends Fragment {
                             );
 
                             FrameLayout.LayoutParams camViewLayout = new FrameLayout.LayoutParams(
-                                    frameContainerLayout.getWidth(),
-                                    frameContainerLayout.getHeight()
+                                frameContainerLayout.getWidth(),
+                                frameContainerLayout.getHeight()
                             );
                             camViewLayout.gravity = Gravity.CENTER_HORIZONTAL | Gravity.CENTER_VERTICAL;
                             frameCamContainerLayout.setLayoutParams(camViewLayout);
@@ -776,8 +776,8 @@ public class CameraActivity extends Fragment {
                         }
                         // switch width/height when rotating 90/270 deg
                         Rect rect = orientation == 90 || orientation == 270
-                                ? new Rect(0, 0, size.height, size.width)
-                                : new Rect(0, 0, size.width, size.height);
+                            ? new Rect(0, 0, size.height, size.width)
+                            : new Rect(0, 0, size.width, size.height);
                         YuvImage yuvImage = new YuvImage(bytes, parameters.getPreviewFormat(), rect.width(), rect.height(), null);
                         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
                         yuvImage.compressToJpeg(rect, quality, byteArrayOutputStream);
@@ -789,7 +789,7 @@ public class CameraActivity extends Fragment {
                         eventListener.onSnapshotTakenError("IO Error");
                     } finally {
                         mCamera.setPreviewCallback(null);
-                        }
+                    }
                 }
             }
         );

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -178,14 +178,14 @@ public class CameraActivity extends Fragment {
             FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(width, height);
             layoutParams.setMargins(x, y, 0, 0);
             frameContainerLayout =
-                (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
+                    (FrameLayout) view.findViewById(getResources().getIdentifier("frame_container", "id", appResourcesPackage));
             frameContainerLayout.setLayoutParams(layoutParams);
 
             //video view
             mPreview = new Preview(getActivity(), enableOpacity, this);
             mainLayout = (FrameLayout) view.findViewById(getResources().getIdentifier("video_view", "id", appResourcesPackage));
             mainLayout.setLayoutParams(
-                new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT)
+                    new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.MATCH_PARENT)
             );
             mainLayout.addView(mPreview);
             mainLayout.setEnabled(false);
@@ -197,15 +197,11 @@ public class CameraActivity extends Fragment {
     }
 
     private void setupTouchAndBackButton() {
-        final GestureDetector gestureDetector = new GestureDetector(getActivity().getApplicationContext(), new GestureDetector.SimpleOnGestureListener() {
+        final GestureDetector gestureDetector = new GestureDetector(getActivity().getApplicationContext(), new GestureDetector.SimpleOnGestureListener() {});
 
+        gestureDetector.setOnDoubleTapListener(new GestureDetector.OnDoubleTapListener() {
             @Override
-            public boolean onDown(@NonNull MotionEvent e) {
-                return true;
-            }
-
-            @Override
-            public boolean onSingleTapUp(@NonNull MotionEvent e) {
+            public boolean onSingleTapConfirmed(@NonNull MotionEvent event) {
                 if (tapToTakePicture) {
                     takePicture(0, 0, 85);
                 }
@@ -213,152 +209,154 @@ public class CameraActivity extends Fragment {
             }
 
             @Override
-            public void onLongPress(@NonNull MotionEvent event) {
+            public boolean onDoubleTap(@NonNull MotionEvent event) {
                 if (tapToFocus) {
                     int x = (int) event.getX(0);
                     int y = (int) event.getY(0);
-                    setFocusArea(x, y, new Camera.AutoFocusCallback() {
-                        public void onAutoFocus(boolean success, Camera camera) {
-                            if (success) {
-                                eventListener.onFocusSet(x, y);
-                            } else {
-                                Log.d(TAG, "onTouch:" + " setFocusArea() did not succeed");
-                            }
+                    setFocusArea(x, y, (success, camera) -> {
+                        if (success) {
+                            eventListener.onFocusSet(x, y);
+                        } else {
+                            Log.d(TAG, "onTouch:" + " setFocusArea() did not succeed");
                         }
                     });
                 }
+                return false;
+            }
+
+            @Override
+            public boolean onDoubleTapEvent(@NonNull MotionEvent event) {
+                return false;
             }
         });
 
-        gestureDetector.setIsLongpressEnabled(true);
-
         getActivity()
-            .runOnUiThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        frameContainerLayout.setClickable(true);
-                        frameContainerLayout.setOnTouchListener(
-                            new View.OnTouchListener() {
-                                private int mLastTouchX;
-                                private int mLastTouchY;
-                                private int mPosX = 0;
-                                private int mPosY = 0;
+                .runOnUiThread(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                frameContainerLayout.setClickable(true);
+                                frameContainerLayout.setOnTouchListener(
+                                        new View.OnTouchListener() {
+                                            private int mLastTouchX;
+                                            private int mLastTouchY;
+                                            private int mPosX = 0;
+                                            private int mPosY = 0;
 
-                                @Override
-                                public boolean onTouch(View v, MotionEvent event) {
-                                    FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) frameContainerLayout.getLayoutParams();
+                                            @Override
+                                            public boolean onTouch(View v, MotionEvent event) {
+                                                FrameLayout.LayoutParams layoutParams = (FrameLayout.LayoutParams) frameContainerLayout.getLayoutParams();
 
-                                    boolean isSingleTapTouch = gestureDetector.onTouchEvent(event);
-                                    int action = event.getAction();
-                                    int eventCount = event.getPointerCount();
-                                    Log.d(TAG, "onTouch event, action, count: " + event + ", " + action + ", " + eventCount);
-                                    if (action == MotionEvent.ACTION_DOWN) {
-                                        mDist = 0;
-                                    }
-                                    if (eventCount > 1) {
-                                        // handle multi-touch events
-                                        Camera.Parameters params = mCamera.getParameters();
-                                        if (action == MotionEvent.ACTION_MOVE && params.isZoomSupported()) {
-                                            handleZoom(event, params);
-                                        }
-                                    } else if((action == MotionEvent.ACTION_MOVE || !isSingleTapTouch) && dragEnabled) {
-                                        int x;
-                                        int y;
-
-                                        switch (event.getAction()) {
-                                            case MotionEvent.ACTION_DOWN:
-                                                if (mLastTouchX == 0 || mLastTouchY == 0) {
-                                                    mLastTouchX = (int) event.getRawX() - layoutParams.leftMargin;
-                                                    mLastTouchY = (int) event.getRawY() - layoutParams.topMargin;
-                                                } else {
-                                                    mLastTouchX = (int) event.getRawX();
-                                                    mLastTouchY = (int) event.getRawY();
+                                                boolean isSingleTapTouch = gestureDetector.onTouchEvent(event);
+                                                int action = event.getAction();
+                                                int eventCount = event.getPointerCount();
+                                                Log.d(TAG, "onTouch event, action, count: " + event + ", " + action + ", " + eventCount);
+                                                if (action == MotionEvent.ACTION_DOWN) {
+                                                    mDist = 0;
                                                 }
-                                                break;
-                                            case MotionEvent.ACTION_MOVE:
-                                                x = (int) event.getRawX();
-                                                y = (int) event.getRawY();
+                                                if (eventCount > 1) {
+                                                    // handle multi-touch events
+                                                    Camera.Parameters params = mCamera.getParameters();
+                                                    if (action == MotionEvent.ACTION_MOVE && params.isZoomSupported()) {
+                                                        handleZoom(event, params);
+                                                    }
+                                                } else if((action == MotionEvent.ACTION_MOVE || !isSingleTapTouch) && dragEnabled) {
+                                                    int x;
+                                                    int y;
 
-                                                final float dx = x - mLastTouchX;
-                                                final float dy = y - mLastTouchY;
+                                                    switch (event.getAction()) {
+                                                        case MotionEvent.ACTION_DOWN:
+                                                            if (mLastTouchX == 0 || mLastTouchY == 0) {
+                                                                mLastTouchX = (int) event.getRawX() - layoutParams.leftMargin;
+                                                                mLastTouchY = (int) event.getRawY() - layoutParams.topMargin;
+                                                            } else {
+                                                                mLastTouchX = (int) event.getRawX();
+                                                                mLastTouchY = (int) event.getRawY();
+                                                            }
+                                                            break;
+                                                        case MotionEvent.ACTION_MOVE:
+                                                            x = (int) event.getRawX();
+                                                            y = (int) event.getRawY();
 
-                                                mPosX += dx;
-                                                mPosY += dy;
+                                                            final float dx = x - mLastTouchX;
+                                                            final float dy = y - mLastTouchY;
 
-                                                layoutParams.leftMargin = mPosX;
-                                                layoutParams.topMargin = mPosY;
+                                                            mPosX += dx;
+                                                            mPosY += dy;
 
-                                                frameContainerLayout.setLayoutParams(layoutParams);
+                                                            layoutParams.leftMargin = mPosX;
+                                                            layoutParams.topMargin = mPosY;
 
-                                                // Remember this touch position for the next move event
-                                                mLastTouchX = x;
-                                                mLastTouchY = y;
+                                                            frameContainerLayout.setLayoutParams(layoutParams);
 
-                                                break;
-                                            default:
-                                                break;
+                                                            // Remember this touch position for the next move event
+                                                            mLastTouchX = x;
+                                                            mLastTouchY = y;
+
+                                                            break;
+                                                        default:
+                                                            break;
+                                                    }
+                                                }
+                                                return true;
+                                            }
                                         }
-                                    }
-                                    return true;
-                                }
+                                );
+                                frameContainerLayout.setFocusableInTouchMode(true);
+                                frameContainerLayout.requestFocus();
+                                frameContainerLayout.setOnKeyListener(
+                                        new View.OnKeyListener() {
+                                            @Override
+                                            public boolean onKey(View v, int keyCode, android.view.KeyEvent event) {
+                                                if (keyCode == android.view.KeyEvent.KEYCODE_BACK) {
+                                                    eventListener.onBackButton();
+                                                    return true;
+                                                }
+                                                return false;
+                                            }
+                                        }
+                                );
                             }
-                        );
-                        frameContainerLayout.setFocusableInTouchMode(true);
-                        frameContainerLayout.requestFocus();
-                        frameContainerLayout.setOnKeyListener(
-                            new View.OnKeyListener() {
-                                @Override
-                                public boolean onKey(View v, int keyCode, android.view.KeyEvent event) {
-                                    if (keyCode == android.view.KeyEvent.KEYCODE_BACK) {
-                                        eventListener.onBackButton();
-                                        return true;
-                                    }
-                                    return false;
+
+                            private float mDist = 0F;
+
+                            private void handleZoom(MotionEvent event, Camera.Parameters params) {
+                                if (mCamera == null) {
+                                    return;
                                 }
+
+                                mCamera.cancelAutoFocus();
+
+                                int maxZoom = params.getMaxZoom();
+                                int zoom = params.getZoom();
+                                float newDist = getFingerSpacing(event);
+                                float distDifference = newDist - mDist;
+
+                                // avoid zoom jumps
+                                if(mDist == 0) {
+                                    mDist = newDist;
+                                    return;
+                                }
+
+                                int zoomDifference = 0;
+                                int zoomFactor = 10;
+                                int maximumZoomStep = 10;
+
+                                if (newDist > mDist) {
+                                    //zoom in;
+                                    zoomDifference = Math.min(Math.round(distDifference / zoomFactor), maximumZoomStep);
+                                    zoom = Math.min(maxZoom, zoom + zoomDifference);
+                                } else if (newDist < mDist) {
+                                    //zoom out
+                                    zoomDifference = Math.max(Math.round(distDifference / zoomFactor), -maximumZoomStep);
+                                    zoom = Math.max(0, zoom + zoomDifference);
+                                }
+                                mDist = newDist;
+                                params.setZoom(zoom);
+                                mCamera.setParameters(params);
                             }
-                        );
-                    }
-
-                    private float mDist = 0F;
-
-                    private void handleZoom(MotionEvent event, Camera.Parameters params) {
-                        if (mCamera == null) {
-                            return;
                         }
-
-                        mCamera.cancelAutoFocus();
-
-                        int maxZoom = params.getMaxZoom();
-                        int zoom = params.getZoom();
-                        float newDist = getFingerSpacing(event);
-                        float distDifference = newDist - mDist;
-
-                        // avoid zoom jumps
-                        if(mDist == 0) {
-                            mDist = newDist;
-                            return;
-                        }
-
-                        int zoomDifference = 0;
-                        int zoomFactor = 10;
-                        int maximumZoomStep = 10;
-
-                        if (newDist > mDist) {
-                            //zoom in;
-                            zoomDifference = Math.min(Math.round(distDifference / zoomFactor), maximumZoomStep);
-                            zoom = Math.min(maxZoom, zoom + zoomDifference);
-                        } else if (newDist < mDist) {
-                            //zoom out
-                            zoomDifference = Math.max(Math.round(distDifference / zoomFactor), -maximumZoomStep);
-                            zoom = Math.max(0, zoom + zoomDifference);
-                        }
-                        mDist = newDist;
-                        params.setZoom(zoom);
-                        mCamera.setParameters(params);
-                    }
-                }
-            );
+                );
     }
 
     private void setDefaultCameraId() {
@@ -401,33 +399,33 @@ public class CameraActivity extends Fragment {
         Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
 
         final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(
-            getResources().getIdentifier("frame_container", "id", appResourcesPackage)
+                getResources().getIdentifier("frame_container", "id", appResourcesPackage)
         );
 
         ViewTreeObserver viewTreeObserver = frameContainerLayout.getViewTreeObserver();
 
         if (viewTreeObserver.isAlive()) {
             viewTreeObserver.addOnGlobalLayoutListener(
-                new ViewTreeObserver.OnGlobalLayoutListener() {
-                    @Override
-                    public void onGlobalLayout() {
-                        frameContainerLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-                        frameContainerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
-                        Activity activity = getActivity();
-                        if (isAdded() && activity != null) {
-                            final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(
-                                getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
-                            );
+                    new ViewTreeObserver.OnGlobalLayoutListener() {
+                        @Override
+                        public void onGlobalLayout() {
+                            frameContainerLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                            frameContainerLayout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+                            Activity activity = getActivity();
+                            if (isAdded() && activity != null) {
+                                final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(
+                                        getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
+                                );
 
-                            FrameLayout.LayoutParams camViewLayout = new FrameLayout.LayoutParams(
-                                frameContainerLayout.getWidth(),
-                                frameContainerLayout.getHeight()
-                            );
-                            camViewLayout.gravity = Gravity.CENTER_HORIZONTAL | Gravity.CENTER_VERTICAL;
-                            frameCamContainerLayout.setLayoutParams(camViewLayout);
+                                FrameLayout.LayoutParams camViewLayout = new FrameLayout.LayoutParams(
+                                        frameContainerLayout.getWidth(),
+                                        frameContainerLayout.getHeight()
+                                );
+                                camViewLayout.gravity = Gravity.CENTER_HORIZONTAL | Gravity.CENTER_VERTICAL;
+                                frameCamContainerLayout.setLayoutParams(camViewLayout);
+                            }
                         }
                     }
-                }
             );
         }
     }
@@ -451,16 +449,16 @@ public class CameraActivity extends Fragment {
         super.onConfigurationChanged(newConfig);
 
         final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(
-            getResources().getIdentifier("frame_container", "id", appResourcesPackage)
+                getResources().getIdentifier("frame_container", "id", appResourcesPackage)
         );
 
         final int previousOrientation = frameContainerLayout.getHeight() > frameContainerLayout.getWidth()
-            ? Configuration.ORIENTATION_PORTRAIT
-            : Configuration.ORIENTATION_LANDSCAPE;
+                ? Configuration.ORIENTATION_PORTRAIT
+                : Configuration.ORIENTATION_LANDSCAPE;
         // Checks if the orientation of the screen has changed
         if (newConfig.orientation != previousOrientation) {
             final RelativeLayout frameCamContainerLayout = (RelativeLayout) view.findViewById(
-                getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
+                    getResources().getIdentifier("frame_camera_cont", "id", appResourcesPackage)
             );
 
             frameContainerLayout.getLayoutParams().width = frameCamContainerLayout.getHeight();
@@ -640,10 +638,10 @@ public class CameraActivity extends Fragment {
     };
 
     private Camera.Size getOptimalPictureSize(
-        final int width,
-        final int height,
-        final Camera.Size previewSize,
-        final List<Camera.Size> supportedSizes
+            final int width,
+            final int height,
+            final Camera.Size previewSize,
+            final List<Camera.Size> supportedSizes
     ) {
         /*
       get the supportedPictureSize that:
@@ -704,8 +702,8 @@ public class CameraActivity extends Fragment {
                 } else {
                     // check if this pictureSize closer to requested width and height
                     if (
-                        Math.abs(width * height - supportedSize.width * supportedSize.height) <
-                        Math.abs(width * height - size.width * size.height)
+                            Math.abs(width * height - supportedSize.width * supportedSize.height) <
+                                    Math.abs(width * height - size.width * size.height)
                     ) {
                         size.width = supportedSize.width;
                         size.height = supportedSize.height;
@@ -762,36 +760,36 @@ public class CameraActivity extends Fragment {
 
     public void takeSnapshot(final int quality) {
         mCamera.setPreviewCallback(
-            new Camera.PreviewCallback() {
-                @Override
-                public void onPreviewFrame(byte[] bytes, Camera camera) {
-                    try {
-                        Camera.Parameters parameters = camera.getParameters();
-                        Camera.Size size = parameters.getPreviewSize();
-                        int orientation = mPreview.getDisplayOrientation();
-                        if (mPreview.getCameraFacing() == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-                            bytes = rotateNV21(bytes, size.width, size.height, (360 - orientation) % 360);
-                        } else {
-                            bytes = rotateNV21(bytes, size.width, size.height, orientation);
+                new Camera.PreviewCallback() {
+                    @Override
+                    public void onPreviewFrame(byte[] bytes, Camera camera) {
+                        try {
+                            Camera.Parameters parameters = camera.getParameters();
+                            Camera.Size size = parameters.getPreviewSize();
+                            int orientation = mPreview.getDisplayOrientation();
+                            if (mPreview.getCameraFacing() == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+                                bytes = rotateNV21(bytes, size.width, size.height, (360 - orientation) % 360);
+                            } else {
+                                bytes = rotateNV21(bytes, size.width, size.height, orientation);
+                            }
+                            // switch width/height when rotating 90/270 deg
+                            Rect rect = orientation == 90 || orientation == 270
+                                    ? new Rect(0, 0, size.height, size.width)
+                                    : new Rect(0, 0, size.width, size.height);
+                            YuvImage yuvImage = new YuvImage(bytes, parameters.getPreviewFormat(), rect.width(), rect.height(), null);
+                            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                            yuvImage.compressToJpeg(rect, quality, byteArrayOutputStream);
+                            byte[] data = byteArrayOutputStream.toByteArray();
+                            byteArrayOutputStream.close();
+                            eventListener.onSnapshotTaken(Base64.encodeToString(data, Base64.NO_WRAP));
+                        } catch (IOException e) {
+                            Log.d(TAG, "CameraPreview IOException");
+                            eventListener.onSnapshotTakenError("IO Error");
+                        } finally {
+                            mCamera.setPreviewCallback(null);
                         }
-                        // switch width/height when rotating 90/270 deg
-                        Rect rect = orientation == 90 || orientation == 270
-                            ? new Rect(0, 0, size.height, size.width)
-                            : new Rect(0, 0, size.width, size.height);
-                        YuvImage yuvImage = new YuvImage(bytes, parameters.getPreviewFormat(), rect.width(), rect.height(), null);
-                        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                        yuvImage.compressToJpeg(rect, quality, byteArrayOutputStream);
-                        byte[] data = byteArrayOutputStream.toByteArray();
-                        byteArrayOutputStream.close();
-                        eventListener.onSnapshotTaken(Base64.encodeToString(data, Base64.NO_WRAP));
-                    } catch (IOException e) {
-                        Log.d(TAG, "CameraPreview IOException");
-                        eventListener.onSnapshotTakenError("IO Error");
-                    } finally {
-                        mCamera.setPreviewCallback(null);
                     }
                 }
-            }
         );
     }
 
@@ -857,20 +855,20 @@ public class CameraActivity extends Fragment {
                     mCamera.takePicture(shutterCallback, null, jpegPictureCallback);
                 }
             }
-                .start();
+                    .start();
         } else {
             canTakePicture = true;
         }
     }
 
     public void startRecord(
-        final String filePath,
-        final String camera,
-        final int width,
-        final int height,
-        final int quality,
-        final boolean withFlash,
-        final int maxDuration
+            final String filePath,
+            final String camera,
+            final int width,
+            final int height,
+            final int quality,
+            final boolean withFlash,
+            final int maxDuration
     ) {
         Log.d(TAG, "CameraPreview startRecord camera: " + camera + " width: " + width + ", height: " + height + ", quality: " + quality);
         Activity activity = getActivity();
@@ -1022,10 +1020,10 @@ public class CameraActivity extends Fragment {
             y = height - 100;
         }
         return new Rect(
-            Math.round((x - 100) * 2000 / width - 1000),
-            Math.round((y - 100) * 2000 / height - 1000),
-            Math.round((x + 100) * 2000 / width - 1000),
-            Math.round((y + 100) * 2000 / height - 1000)
+                Math.round((x - 100) * 2000 / width - 1000),
+                Math.round((y - 100) * 2000 / height - 1000),
+                Math.round((x + 100) * 2000 / width - 1000),
+                Math.round((y + 100) * 2000 / height - 1000)
         );
     }
 

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -204,6 +204,7 @@ public class CameraActivity extends Fragment {
             public boolean onSingleTapConfirmed(@NonNull MotionEvent event) {
                 if (tapToTakePicture) {
                     takePicture(0, 0, 85);
+                    return true;
                 }
                 return false;
             }
@@ -220,6 +221,7 @@ public class CameraActivity extends Fragment {
                             Log.d(TAG, "onTouch:" + " setFocusArea() did not succeed");
                         }
                     });
+                    return true;
                 }
                 return false;
             }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -6,7 +6,7 @@ import AVFoundation
  * here: https://capacitor.ionicframework.com/docs/plugins/ios
  */
 @objc(CameraPreview)
-public class CameraPreview: CAPPlugin {
+public class CameraPreview: CAPPlugin{
 
     var previewView: UIView!
     var cameraPosition = String()
@@ -22,6 +22,7 @@ public class CameraPreview: CAPPlugin {
     var enableZoom: Bool?
     var highResolutionOutput: Bool = false
     var disableAudio: Bool = false
+    var onFocusSetCallbackId: String? = nil
 
     @objc func rotated() {
         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!
@@ -39,6 +40,15 @@ public class CameraPreview: CAPPlugin {
         }
 
         cameraController.updateVideoOrientation()
+    }
+    
+    @objc func onFocusSet(screenPosition: CGPoint) {
+        if self.onFocusSetCallbackId != nil {
+            let call = self.bridge?.savedCall(withID: self.onFocusSetCallbackId!)
+            if call != nil {
+                call!.resolve(["x": screenPosition.x, "y": screenPosition.y])
+            }
+        }
     }
 
     @objc func start(_ call: CAPPluginCall) {
@@ -102,6 +112,8 @@ public class CameraPreview: CAPPlugin {
                             NotificationCenter.default.addObserver(self, selector: #selector(CameraPreview.rotated), name: UIDevice.orientationDidChangeNotification, object: nil)
                         }
 
+                        self.cameraController.setOnFocusSetCallback(callback: self.onFocusSet)
+
                         call.resolve()
 
                     }
@@ -126,12 +138,17 @@ public class CameraPreview: CAPPlugin {
                 self.cameraController.captureSession?.stopRunning()
                 self.previewView.removeFromSuperview()
                 self.webView?.isOpaque = true
+                if self.onFocusSetCallbackId != nil {
+                    self.bridge?.releaseCall(withID: self.onFocusSetCallbackId!)
+                    self.onFocusSetCallbackId = nil
+                }
                 call.resolve()
             } else {
                 call.reject("camera already stopped")
             }
         }
     }
+    
     // Get user's cache directory path
     @objc func getTempFilePath() -> URL {
         let path = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
@@ -355,8 +372,13 @@ public class CameraPreview: CAPPlugin {
     }
 
     @objc func subscribeToFocusSet(_ call: CAPPluginCall) {
-        // to be implemented if necessary
-        call.resolve();
+        if self.onFocusSetCallbackId != nil {
+            self.bridge?.releaseCall(withID: self.onFocusSetCallbackId!)
+            self.onFocusSetCallbackId = nil
+        }
+
+        self.onFocusSetCallbackId = call.callbackId
+        call.keepAlive = true
     }
 
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -6,7 +6,7 @@ import AVFoundation
  * here: https://capacitor.ionicframework.com/docs/plugins/ios
  */
 @objc(CameraPreview)
-public class CameraPreview: CAPPlugin{
+public class CameraPreview: CAPPlugin {
 
     var previewView: UIView!
     var cameraPosition = String()


### PR DESCRIPTION
Der Trigger ist jetzt doch ein double-tap - iOS hat ein Textauswahl und -kopier Feature das mit long-press getriggert wird weil es auf einem anderen Layer wohl Text erkennt. Das lässt sich nicht so leicht verhindern oder ausstellen.

TODO: Plugin update für master und tmax nach merge